### PR TITLE
Use instance variables so class is easier to extend

### DIFF
--- a/Oled.js
+++ b/Oled.js
@@ -35,7 +35,7 @@ class Oled {
     this.HEIGHT         = opts.height || 64;
     this.WIDTH          = opts.width || 128;
     this.DATA_SIZE      = opts.dataSize || 16;
-    this.MAX_PAGE_COUNT = opts.maxPageCount || 8;
+    this.MAX_PAGE_COUNT = opts.maxPageCount || (this.HEIGHT / 8);
 
     // new blank buffer
     // init with 0xff to make sure that the inital clearDisplay() call will update all pixels.


### PR DESCRIPTION
Hi, and thanks for the great library! 

I am using your library as a starting point for working with a sh1107-based display. I would like to extend from your sh1106 implementation, but as the default WIDTH and HEIGHT can't be set / overwritten this is quite hard to do. This PR uses this.WIDTH instead of WIDTH inside the class, and this.WIDTH can be initialized via opts (but still defaults to your chosen values).

Everything should still work as before, but it is a bit more flexible.